### PR TITLE
🔨Remove Alpine edge repo usage

### DIFF
--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -13,7 +13,7 @@ RUN \
         git=2.26.2-r0 \
     \
     && apk add --no-cache \
-        go@edge=1.13.14-r0 \
+        go=1.13.14-r0 \
         libqrencode=4.0.2-r0 \
         openresolv=3.10.0-r0 \
         wireguard-tools@edge=1.0.20200510-r0 \

--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -16,7 +16,7 @@ RUN \
         go=1.13.14-r0 \
         libqrencode=4.0.2-r0 \
         openresolv=3.10.0-r0 \
-        wireguard-tools@edge=1.0.20200510-r0 \
+        wireguard-tools=1.0.20200510-r0 \
     \
     && git clone --branch "v0.0.20200320" --depth=1 \
         "https://git.zx2c4.com/wireguard-go" /tmp/wireguard \


### PR DESCRIPTION
# Proposed Changes

The packages used exist with the same versions in 3.12 (I would assume in the past they were previously only on edge).  It would make sense to me to use those rather than the edge versions in case of issues.

## Related Issues

None