### PR TITLE
Upgrade add-on base image to 9.1.2

### DIFF
--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/base:8.0.5
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.2
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -10,15 +10,15 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r2 \
-        git=2.26.2-r0 \
+        git=2.30.0-r0 \
     \
     && apk add --no-cache \
-        go=1.13.15-r0 \
-        libqrencode=4.0.2-r0 \
-        openresolv=3.10.0-r0 \
-        wireguard-tools=1.0.20200510-r0 \
+        go=1.15.7-r0 \
+        libqrencode=4.1.1-r0 \
+        openresolv=3.12.0-r0 \
+        wireguard-tools=1.0.20200827-r1 \
     \
-    && git clone --branch "v0.0.20200320" --depth=1 \
+    && git clone --branch "0.0.20200320" --depth=1 \
         "https://git.zx2c4.com/wireguard-go" /tmp/wireguard \
     \
     && cd /tmp/wireguard \

--- a/wireguard/build.json
+++ b/wireguard/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "hassioaddons/base-aarch64:8.0.5",
-    "amd64": "hassioaddons/base-amd64:8.0.5",
-    "armhf": "hassioaddons/base-armhf:8.0.5",
-    "armv7": "hassioaddons/base-armv7:8.0.5",
-    "i386": "hassioaddons/base-i386:8.0.5"
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.2",
+    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.2",
+    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.2",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.2",
+    "i386": "ghcr.io/hassio-addons/base/i386:9.1.2"
   }
 }


### PR DESCRIPTION
# Proposed Changes

Upgrade the add-on base image to 9.1.2 (including all related packages, as this brings the add-on to Alpine 3.13).
