### PR TITLE
Update Adguard instructions for v4.0

### DIFF
--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -118,9 +118,9 @@ address of HomeAssistant as a DNS IP address in the list.** This will cause
 your clients to use those. What this does, it effectively gives your clients
 ad-filtering (e.g., your mobile phone), while not at home.
 
-*Note: This used to recommend adding `172.30.32.1` as the DNS IP Address.
+_Note: This used to recommend adding `172.30.32.1` as the DNS IP Address.
 Starting in v4.0.0 of the Adguard add-on you'll need to use the LAN
-address. You will also need to update any previously configured clients.
+address. You will also need to update any previously configured clients._
 
 ### Option: `server.private_key` _(optional)_
 

--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -113,14 +113,14 @@ A list of DNS servers used by the add-on and the configuration generated for
 the clients. This configuration option is optional, and if no DNS servers are
 set, it will use the built-in DNS server from Hass.io.
 
-**If you are running the [AdGuard][adguard] add-on, you can add the LAN address
-of HomeAssistant as a DNS IP address in the list.** This will cause your clients
-to use those. What this does, it effectively making your clients to have
+**If you are running the [AdGuard][adguard] add-on, you can add the LAN
+address of HomeAssistant as a DNS IP address in the list.** This will cause
+your clients to use those. What this does, it effectively gives your clients
 ad-filtering (e.g., your mobile phone), while not at home.
 
-*Note: This used to recommend adding `172.30.32.1` as the IP address for Adguard.
-Starting in v4.0.0 of that add-on that won't work anymore, you'll need to use
-the LAN address. You will also need to update any previously configured clients.
+*Note: This used to recommend adding `172.30.32.1` as the DNS IP Address.
+Starting in v4.0.0 of the Adguard add-on you'll need to use the LAN
+address. You will also need to update any previously configured clients.
 
 ### Option: `server.private_key` _(optional)_
 

--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -113,9 +113,9 @@ A list of DNS servers used by the add-on and the configuration generated for
 the clients. This configuration option is optional, and if no DNS servers are
 set, it will use the built-in DNS server from Hass.io.
 
-**If you are running the [AdGuard][adguard] add-on, you can add the LAN address 
-of HomeAssistant as a DNS IP address in the list.** This will cause your clients 
-to use those. What this does, it effectively making your clients to have 
+**If you are running the [AdGuard][adguard] add-on, you can add the LAN address
+of HomeAssistant as a DNS IP address in the list.** This will cause your clients
+to use those. What this does, it effectively making your clients to have
 ad-filtering (e.g., your mobile phone), while not at home.
 
 *Note: This used to recommend adding `172.30.32.1` as the IP address for Adguard.

--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -114,7 +114,7 @@ the clients. This configuration option is optional, and if no DNS servers are
 set, it will use the built-in DNS server from Hass.io.
 
 **If you are running the [AdGuard][adguard] add-on, you can add the LAN
-address of HomeAssistant as a DNS IP address in the list.** This will cause
+address of Home Assistant as a DNS IP address in the list.** This will cause
 your clients to use those. What this does, it effectively gives your clients
 ad-filtering (e.g., your mobile phone), while not at home.
 
@@ -459,7 +459,10 @@ If you have, sharing would be appreciated!
   device and load the new client configuration (e.g., by scanning the QR
   code).
 - If you are running the [AdGuard][adguard] add-on,
-  you can add `172.30.32.1` as a DNS IP address the list to use it.
+  you can add the LAN address of Home Assistant to use it as a DNS IP
+  address to use it. Note that listing `172.30.32.1` here no longer works
+  as of v4.0.0 of the Adguard add-on. So if your previous configuration
+  is no longer working this may be why.
 - If you run a protection service like CloudFlare on your `server.host`
   address, please remember, that WireGuard will try to connect to CloudFlare
   in that case (and not your Home). Please consider using your IP

--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -113,10 +113,14 @@ A list of DNS servers used by the add-on and the configuration generated for
 the clients. This configuration option is optional, and if no DNS servers are
 set, it will use the built-in DNS server from Hass.io.
 
-**If you are running the [AdGuard][adguard] add-on,
-you can add `172.30.32.1` as a DNS IP address in the list.** This will cause your
-clients to use those. What this does, it effectively making your clients
-to have ad-filtering (e.g., your mobile phone), while not at home.
+**If you are running the [AdGuard][adguard] add-on, you can add the LAN address 
+of HomeAssistant as a DNS IP address in the list.** This will cause your clients 
+to use those. What this does, it effectively making your clients to have 
+ad-filtering (e.g., your mobile phone), while not at home.
+
+*Note: This used to recommend adding `172.30.32.1` as the IP address for Adguard.
+Starting in v4.0.0 of that add-on that won't work anymore, you'll need to use
+the LAN address. You will also need to update any previously configured clients.
 
 ### Option: `server.private_key` _(optional)_
 


### PR DESCRIPTION
# Proposed Changes
Starting with v4.0 of the Adguard add-on, Adguard is no longer listening for DNS requests on `172.30.32.1`. You must now refer to the LAN address of HomeAssistant instead. Updated the doc's Adguard instructions to say this.

I also added an explainer note for users upgrading a previously working configuration. I'm not certain if this is the right place for that but thought it should be published somewhere. Perhaps that should just be published to the changelog of this addon?

## Related Issues

https://community.home-assistant.io/t/issues-with-wireguard-using-adguard-home-for-dns/290143?u=adhawk
https://community.home-assistant.io/t/home-assistant-community-add-on-wireguard/134662/237
