### PR TITLE
Update DOCS.md

### DIFF
--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -114,7 +114,7 @@ the clients. This configuration option is optional, and if no DNS servers are
 set, it will use the built-in DNS server from Hass.io.
 
 **If you are running the [AdGuard][adguard] add-on,
-you can add `172.30.32.1` as a DNS IP address in the list.** This will cause your
+you can add the LAN IP of your Home Assistant instance as a DNS IP address in the list.** This will cause your
 clients to use those. What this does, it effectively making your clients
 to have ad-filtering (e.g., your mobile phone), while not at home.
 


### PR DESCRIPTION
If AdGuard addon is used as DNS server, the former Home Assistant internal IP address cannot be used anymore. Use the local IP address of your Home Assistant instance instead

# Proposed Changes

The internal IP address for AdGuard DNS addon doesn't work anymore in Wireguard. Instruction must be changed accordingly that the LAN IP address of Home Assistant must be used instead.

## Related Issues

N/A
> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
