### PR TITLE
Clarified ListenPort-documentation

### DIFF
--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -466,8 +466,8 @@ If you have, sharing would be appreciated!
   solving this by editing the "Endpoint" setting on the client on the device
   in the connection profile.
 - We had reports of people with connection issues on the client side, being
-  resolved by configuring/setting the "Listen port" to `51820` on the client
-  device in the connection profile.
+  resolved by configuring/setting the `ListenPort = 51820` on the client
+  device in the connection profile (in `[Interface]` section).
 
 ## Changelog & Releases
 


### PR DESCRIPTION
Added a bit more clear documentation in the troubleshooting-section to more easily understand where to put the suggested fix.

# Proposed Changes

A minor change to make the documentation a bit more clear for the users on what to do when configuring.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
