### PR TITLE
Make API service honor port setting

### DIFF
--- a/wireguard/rootfs/etc/services.d/api/run
+++ b/wireguard/rootfs/etc/services.d/api/run
@@ -15,6 +15,9 @@ declare public_key
 declare transfer_rx
 declare transfer_tx
 
+PORT=$(bashio::addon.port "80/tcp")
+if [[ $PORT -eq 0 ]]; then exit; fi
+
 while true; do
     # Get information from wg
     peers=()
@@ -48,5 +51,5 @@ while true; do
     fi
 
     echo -e "HTTP/1.1 200 OK\r\nContent-type: application/json\r\n\r\n${json}" \
-        | nc -l -p 80 > /dev/null
+        | nc -l -p $PORT > /dev/null
 done


### PR DESCRIPTION
# Proposed Changes

Changing the API service to honor the port setting in the add-on's network configuration. So far, it would always listen on port 80, blocking the default HTTP port for use by other add-ons.