### PR TITLE
guard wg show status with log level

### DIFF
--- a/wireguard/rootfs/etc/services.d/status/run
+++ b/wireguard/rootfs/etc/services.d/status/run
@@ -5,4 +5,6 @@
 # ==============================================================================
 sleep 30
 bashio::log.info "Requesting current status from WireGuard..."
-exec wg show
+while read line; do
+  bashio::log.info "${line}"
+done < <(wg show)


### PR DESCRIPTION
# Proposed Changes

wg show current spews into the log regardless of log_level setting. This changed only logs the status's wg show  at/above info level.
## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
