### PR TITLE
print qrcode as text in logs

### DIFF
--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -35,7 +35,7 @@ Follow the following steps for installation & a quick start:
 1. Forward port `51820` (UDP!) in your router to your Hass.io IP.
 1. Download/Open the file `/ssl/wireguard/myphone/qrcode.png` stored on your
    Hass.io machine, e.g., using Samba, Visual Studio Code or the Configurator
-   add-on.
+   add-on. You can also find the QR Code in the add-on logs.
 1. Install the WireGuard app on your phone.
 1. Add a new WireGuard connection to your phone, by scanning the QR code.
 1. Connect!

--- a/wireguard/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard/rootfs/etc/cont-init.d/config.sh
@@ -291,6 +291,10 @@ for peer in $(bashio::config 'peers|keys'); do
     # Generate QR code with client configuration
     qrencode -t PNG -o "${config_dir}/qrcode.png" < "${config_dir}/client.conf"
 
+    # Show QR code with client configuration in logs
+    bashio::log.info "QR code for peer ${name}:"
+    qrencode -t ANSI < "${config_dir}/client.conf"
+
     # Store client name for the status API based on public key
     filename=$(sha1sum <<< "${peer_public_key}" | awk '{ print $1 }')
     echo -n "${name}" > "/var/lib/wireguard/${filename}"


### PR DESCRIPTION
# Proposed Changes

In order to lower the bar of getting started with wireguard on HomeAssistant OS, I added the default print of the QR code in the add-on logs. This allows the user to qucikly get access to the QR code and connect right away.

The motivation behind this, is the difficulty of accessing this folder, without having pre-configured the File Editor add-on to allow access to the `/ssl` folder or have any other kind of file transfer up and running.

## Related Issues

No related issue.

## Notes

I haven't tested these commands in this specific environment yet, so this is not tested in HomeAssistant itself.
