### PR TITLE
Use netfilter tables (nf_tables) backend by default

### DIFF
--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -19,6 +19,8 @@ RUN \
         openresolv=3.12.0-r0 \
         wireguard-tools=1.0.20210914-r0 \
     \
+    && ln -sf /sbin/xtables-nft-multi /sbin/ip6tables \
+    && ln -sf /sbin/xtables-nft-multi /sbin/iptables \
     && git clone --branch "0.0.20220316" --depth=1 \
         "https://git.zx2c4.com/wireguard-go" /tmp/wireguard \
     \


### PR DESCRIPTION
# Proposed Changes

Use the more modern netfilter tables (nf_tables) backend by default for iptables. The nf_tables backend will be used in HAOS 9.4 and newer releases and is used in Debian (Supervised) installations already today.

Note: Since the add-on runs in its own network namespace mixing iptables legacy and nf_tables seem not to be problematic in practice. Still, this change makes sure we use the same (and more modern) technology stack on OS side as well as in the add-on.
