### PR TITLE
Replace libqrencode with libqrencode-tools

### DIFF
--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -15,7 +15,7 @@ RUN \
     && apk add --no-cache \
         go=1.21.5-r0 \
         iptables=1.8.10-r1 \
-        libqrencode=4.1.1-r2 \
+        libqrencode-tools=4.1.1-r2 \
         openresolv=3.13.2-r0 \
         wireguard-tools=1.0.20210914-r3 \
     \


### PR DESCRIPTION
# Proposed Changes

Alpine 3.19 move the binary to a separate package. This PR adjusts the add-on to that.

fixes #281
fixed #280 
