### PR TITLE
Update how to disable persistent_keep_alive

### DIFF
--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -292,7 +292,7 @@ By default or when unspecified, this option is set to 25 seconds. This is
 different from the WireGuard default, since the use case for this add-on is
 most likely to be installed in home setups behind a NAT.
 
-If set to "off", this option is disabled.
+If set to 0, this option is disabled.
 
 ### Option: `peers.endpoint` _(optional)_
 


### PR DESCRIPTION
# Proposed Changes

Fails when saving as "off"

![image](https://github.com/hassio-addons/addon-wireguard/assets/19779808/6e345adb-6f48-4dda-a853-6d6d44aff64e)

Works when saving as "0" (and that makes its way into the corresponding client config file.

"0" is the officially documented way of disabling this feature as per https://www.wireguard.com/quickstart/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation to clarify that setting the option to 0 will disable it, instead of using "off".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->