### PR TITLE
Update config.sh to add PresharedKey to client configuration files

### DIFF
--- a/wireguard/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard/rootfs/etc/cont-init.d/config.sh
@@ -282,6 +282,8 @@ for peer in $(bashio::config 'peers|keys'); do
         echo ""
         echo "[Peer]"
         echo "PublicKey = ${server_public_key}"
+        bashio::config.has_value "peers[${peer}].pre_shared_key" \
+            && echo "PreSharedKey = ${pre_shared_key}"
         echo "Endpoint = ${host}:${port}"
         echo "AllowedIPs = ${allowed_ips}"
         echo "PersistentKeepalive = ${keep_alive}"


### PR DESCRIPTION
Preshared keys were not added to the client config files. Added PresharedKey config item to "Write client configuration file" section

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring `PreSharedKey` for WireGuard peers if a value is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->