### PR TITLE
Documentation: Add summary of what this add-on does and doesn't do

### DIFF
--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -1,8 +1,16 @@
 # Home Assistant Community Add-on: WireGuard
 
 [WireGuard®][wireguard] is an extremely simple yet fast and modern VPN that
-utilizes state-of-the-art cryptography. It aims to be faster, simpler, leaner,
-and more useful than IPsec, while avoiding the massive headache.
+utilizes state-of-the-art cryptography. This add-on allows you to use your 
+Home Assistant add-on as a bridge server, and easily configure and connect
+client devices.
+
+**Note**: installing this add-on does not expose the HA interface to connected
+WireGuard peers.
+
+## About WireGuard
+WireGuard aims to be faster, simpler, leaner, and more useful than IPsec,
+while avoiding the massive headache.
 
 It intends to be considerably more performant than OpenVPN. WireGuard is
 designed as a general-purpose VPN for running on embedded interfaces and


### PR DESCRIPTION
This commit moves some general WireGuard promo copy to its own heading, and adds a short summary of the add-on capabilities to the top of the documentation page.

After several hours of debugging spanning multiple days, I found issue #254, which concluded that what I was trying is apparently not possible. This PR adds this result to the top of the documentation page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced clarity and usability of the WireGuard Home Assistant add-on documentation.
  - Added a new section clarifying that the add-on does not expose the Home Assistant interface to WireGuard peers.
  - Restructured the "About WireGuard" section to emphasize performance advantages over IPsec and OpenVPN.
  - Reformatted installation instructions into a clear step-by-step guide, highlighting the importance of checking logs post-installation.
  - Expanded configuration section with detailed explanations and best practices for various options.
  - Improved troubleshooting section with practical advice for common issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->