### PR TITLE
Mark fields "allowed_ips" and "client_allowed_ips" as required

### DIFF
--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -248,7 +248,7 @@ practice perspective, it is strongly advised to manually provide a public key
 for each of your peers. In that case, the add-on will not generate or configure
 a private key by itself.**
 
-### Option: `peers.allowed_ips` _(optional)_
+### Option: `peers.allowed_ips`
 
 **This configuration only valid for the add-on/server end and does not
 affect client configurations!**
@@ -263,7 +263,7 @@ listed in `peers.addresses`.
 The catch-all `0.0.0.0/0` may be specified for matching all IPv4 addresses,
 and `::/0` may be specified for matching all IPv6 addresses.
 
-### Option: `peers.client_allowed_ips` _(optional)_
+### Option: `peers.client_allowed_ips`
 
 **This configuration only valid for the peer end/client configuration and does
 not affect the server/add-on!**


### PR DESCRIPTION
The add-on refuses to start without them. This fixes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Clarified usage of `peers.allowed_ips` and `peers.client_allowed_ips` in server and client configurations by removing the _(optional)_ tag.
  - Expanded explanation of the `log_level` option for better troubleshooting guidance.
  - Minor formatting adjustments made for improved clarity throughout the document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->