### PR TITLE
Upgrade to hassio-addons/base:17.1.4

### DIFF
--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:16.3.6
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:17.1.4
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -8,23 +8,26 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base
 # hadolint ignore=DL3003
 RUN \
+    apk add --no-cache musl && \
     apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r3 \
-        git=2.45.3-r0 \
-    \
-    && apk add --no-cache \
-        go=1.22.10-r0 \
-        iptables=1.8.10-r3 \
+        git=2.47.2-r0
+
+RUN \
+    apk add --no-cache \
+        go=1.23.6-r0 \
+        iptables=1.8.11-r1 \
         libqrencode-tools=4.1.1-r2 \
-        openresolv=3.13.2-r0 \
+        openresolv=3.13.2-r1 \
         wireguard-tools=1.0.20210914-r4 \
     \
     && ln -sf /sbin/xtables-nft-multi /sbin/ip6tables \
     && ln -sf /sbin/xtables-nft-multi /sbin/iptables \
-    && git clone --branch "0.0.20230223" --depth=1 \
+    && git clone --branch "master" \
         "https://git.zx2c4.com/wireguard-go" /tmp/wireguard \
     \
     && cd /tmp/wireguard \
+    && git checkout 12269c2761734b15625017d8565745096325392f \
     && make \
     && make install \
     \

--- a/wireguard/build.yaml
+++ b/wireguard/build.yaml
@@ -1,8 +1,8 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:16.3.6
-  amd64: ghcr.io/hassio-addons/base:16.3.6
-  armv7: ghcr.io/hassio-addons/base:16.3.6
+  aarch64: ghcr.io/hassio-addons/base:17.1.4
+  amd64: ghcr.io/hassio-addons/base:17.1.4
+  armv7: ghcr.io/hassio-addons/base:17.1.4
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev


### PR DESCRIPTION
Fix musl dependency 1.2.5-r8 -> r9 for alpine 3.21
Upgrade packages to align with alpine 3.21 repository 
Upgrade wireguard-go to the latest commit to avoid golang.org/x/net/internal/socket: invalid reference to syscall.recvmsg message during build with go 1.23

# Proposed Changes

> I just saw that the migration to v17 failed. With the changes in the commit it should succeed again. The image build was successful with linux/arm/v7, linux/arm64/v8, linux/arm/v6 and linux/amd64

## Related Issues

> #221 
