### PR TITLE
Drop support for armv7 systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,8 @@
 ![Project Stage][project-stage-shield]
 [![License][license-shield]](LICENSE.md)
 
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -108,8 +105,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-wireguard.svg
 [commits]: https://github.com/hassio-addons/addon-wireguard/commits/main
 [contributors]: https://github.com/hassio-addons/addon-wireguard/graphs/contributors
@@ -124,7 +119,6 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-wireguard/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-wireguard/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-wireguard.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg

--- a/wireguard/build.yaml
+++ b/wireguard/build.yaml
@@ -2,7 +2,6 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:18.2.1
   amd64: ghcr.io/hassio-addons/base:18.2.1
-  armv7: ghcr.io/hassio-addons/base:18.2.1
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/wireguard/config.yaml
+++ b/wireguard/config.yaml
@@ -8,7 +8,6 @@ codenotary: codenotary@frenck.dev
 arch:
   - aarch64
   - amd64
-  - armv7
 init: false
 ports:
   80/tcp: null


### PR DESCRIPTION
# Proposed Changes

The architecture is deprecated and support for it will drop fully in Home Assistant 2025.12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supported architectures list

* **Chores**
  * Removed support for armhf, armv7, and i386 architectures
  * Application now available only on aarch64 and amd64 platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->