### PR TITLE
Remove deprecated codenotary fields

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/wireguard/build.yaml
+++ b/wireguard/build.yaml
@@ -2,6 +2,3 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:18.2.1
   amd64: ghcr.io/hassio-addons/base:18.2.1
-codenotary:
-  base_image: codenotary@frenck.dev
-  signer: codenotary@frenck.dev

--- a/wireguard/config.yaml
+++ b/wireguard/config.yaml
@@ -4,7 +4,6 @@ version: dev
 slug: wireguard
 description: Fast, modern, secure VPN tunnel
 url: https://github.com/hassio-addons/addon-wireguard
-codenotary: codenotary@frenck.dev
 arch:
   - aarch64
   - amd64


### PR DESCRIPTION
# Proposed Changes

SSIA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Limited Docker build support to aarch64 and amd64 architectures only.
  * Removed code signing verification infrastructure from build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->