### PR TITLE
Add optional web interface for QR codes and config downloads (Ingress-only)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           # The job runs repository-controlled shell after checkout; no later
           # step authenticates to Git, so do not leave a token in .git/config.
           persist-credentials: false
-      # Builds the add-on image and asserts against it, so a dropped
-      # busybox-extras or a loosened ACL cannot pass unnoticed.
+      # Asserts against what the add-on declares, so a dropped busybox-extras
+      # or a loosened Ingress ACL cannot pass unnoticed.
       - name: 🚀 Verify httpd availability and Ingress-only ACL
         run: bash wireguard/tests/webui-acl-smoke.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,5 +21,11 @@ jobs:
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v4
+        with:
+          # The job runs repository-controlled shell after checkout; no later
+          # step authenticates to Git, so do not leave a token in .git/config.
+          persist-credentials: false
+      # Builds the add-on image and asserts against it, so a dropped
+      # busybox-extras or a loosened ACL cannot pass unnoticed.
       - name: 🚀 Verify httpd availability and Ingress-only ACL
         run: bash wireguard/tests/webui-acl-smoke.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,3 +14,12 @@ on:
 jobs:
   workflows:
     uses: hassio-addons/workflows/.github/workflows/addon-ci.yaml@main
+
+  webui-smoke:
+    name: Web UI Ingress ACL smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v4
+      - name: 🚀 Verify httpd availability and Ingress-only ACL
+        run: bash wireguard/tests/webui-acl-smoke.sh

--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -346,19 +346,19 @@ device.
 Because the QR codes and client configurations contain the peers' **private
 keys**, this page is served exclusively through
 [Home Assistant Ingress][ingress] — open it with the **"Open Web UI"** button
-on the add-on page. Access is gated by your Home Assistant login, and the page
-is never exposed on a raw, unauthenticated port. Transport encryption is
-whatever your Home Assistant instance itself uses: Ingress proxies the page over
-the internal Supervisor network, so it is only encrypted end-to-end if you reach
-Home Assistant over HTTPS.
+on the add-on page. Access is gated by your Home Assistant login and protected
+by the transport security of your Home Assistant session (so use HTTPS if you
+reach Home Assistant over an untrusted network); the page is never exposed on a
+raw, unauthenticated port. Note that any user who can open this add-on sees
+**every** peer's key material, not just their own.
 
 Enabling this option does **not** change the WireGuard status API (see below);
 it keeps serving JSON on port `80` as before, so existing REST sensors are
 unaffected.
 
-This option is disabled by default. While it is disabled there is nothing to
-serve, so the add-on's **"Open Web UI"** button will report a connection error
-until you enable it.
+This option is disabled by default. While it is disabled the **"Open Web UI"**
+button shows a short "web interface disabled" notice, and any previously
+generated QR codes and config copies are wiped on the next add-on start.
 
 ## Finding generated client configurations
 

--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -336,6 +336,28 @@ more severe level, e.g., `debug` also shows `info` messages. By default,
 the `log_level` is set to `info`, which is the recommended setting unless
 you are troubleshooting.
 
+### Option: `web_interface` _(optional)_
+
+When set to `true`, the add-on serves a lightweight web page listing every
+peer with its QR code and a download link for its client configuration. This
+saves you from digging through the `/ssl/wireguard` folder to onboard a new
+device.
+
+Because the QR codes and client configurations contain the peers' **private
+keys**, this page is served exclusively through
+[Home Assistant Ingress][ingress] — open it with the **"Open Web UI"** button
+on the add-on page. Access is gated by your Home Assistant login and the
+connection is encrypted by Home Assistant; the page is never exposed on a raw,
+unauthenticated port.
+
+Enabling this option does **not** change the WireGuard status API (see below);
+it keeps serving JSON on port `80` as before, so existing REST sensors are
+unaffected.
+
+This option is disabled by default. While it is disabled there is nothing to
+serve, so the add-on's **"Open Web UI"** button will report a connection error
+until you enable it.
+
 ## Finding generated client configurations
 
 All generated files are stored in `/ssl/wireguard`. This includes the
@@ -541,6 +563,7 @@ SOFTWARE.
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-wireguard/134662?u=frenck
 [frenck]: https://github.com/frenck
 [ha-rest]: https://www.home-assistant.io/integrations/rest/
+[ingress]: https://developers.home-assistant.io/docs/add-ons/presentation#ingress
 [issue]: https://github.com/hassio-addons/addon-wireguard/issues
 [reddit]: https://reddit.com/r/homeassistant
 [releases]: https://github.com/hassio-addons/addon-wireguard/releases

--- a/wireguard/DOCS.md
+++ b/wireguard/DOCS.md
@@ -346,9 +346,11 @@ device.
 Because the QR codes and client configurations contain the peers' **private
 keys**, this page is served exclusively through
 [Home Assistant Ingress][ingress] — open it with the **"Open Web UI"** button
-on the add-on page. Access is gated by your Home Assistant login and the
-connection is encrypted by Home Assistant; the page is never exposed on a raw,
-unauthenticated port.
+on the add-on page. Access is gated by your Home Assistant login, and the page
+is never exposed on a raw, unauthenticated port. Transport encryption is
+whatever your Home Assistant instance itself uses: Ingress proxies the page over
+the internal Supervisor network, so it is only encrypted end-to-end if you reach
+Home Assistant over HTTPS.
 
 Enabling this option does **not** change the WireGuard status API (see below);
 it keeps serving JSON on port `80` as before, so existing REST sensors are

--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -6,13 +6,18 @@ FROM ${BUILD_FROM}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
+# Bump musl to 1.2.5-r12 first: base:19.0.0 pins musl=r10 in its world, but the
+# current Alpine 3.22 repo's build-base -> musl-dev requires r12, so build-base
+# cannot install otherwise. Drop this once the base image ships r12 itself.
 # hadolint ignore=DL3003
 RUN \
-    apk add --no-cache --virtual .build-dependencies \
+    apk add --no-cache musl=1.2.5-r12 \
+    && apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r3 \
         git=2.49.1-r0 \
     \
     && apk add --no-cache \
+        busybox-extras=1.37.0-r20 \
         go=1.24.13-r0 \
         iptables=1.8.11-r1 \
         libqrencode-tools=4.1.1-r3 \

--- a/wireguard/config.yaml
+++ b/wireguard/config.yaml
@@ -35,6 +35,7 @@ options:
       client_allowed_ips: []
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
+  web_interface: bool?
   server:
     host: str
     interface: match(^wg([0-9])+$)?

--- a/wireguard/config.yaml
+++ b/wireguard/config.yaml
@@ -15,6 +15,8 @@ ports_description:
   80/tcp: WireGuard peers status API
   51820/udp: "WireGuard: forward this port in your router"
 hassio_api: true
+ingress: true
+ingress_port: 8099
 privileged:
   - NET_ADMIN
 devices:

--- a/wireguard/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard/rootfs/etc/cont-init.d/config.sh
@@ -351,8 +351,13 @@ HTMLEOF
             continue
         fi
 
-        # Make the client config available for download
-        cp "${config_dir}/client.conf" "${www_dir}/configs/${name}.conf"
+        # Make the client config available for download, from a per-peer
+        # subdirectory so the served basename is always "client.conf". A flat
+        # "configs/${name}.conf" would become "httpd.conf" for a peer named
+        # "httpd" (a schema-valid name), which BusyBox httpd reserves as its
+        # per-directory config file and refuses to serve (403).
+        mkdir -p "${www_dir}/configs/${name}"
+        cp "${config_dir}/client.conf" "${www_dir}/configs/${name}/client.conf"
 
         # Embed the QR code as a base64 data URI
         qr_b64=$(base64 "${config_dir}/qrcode.png" | tr -d '\n')
@@ -361,7 +366,7 @@ HTMLEOF
             echo "  <div class=\"peer\">"
             echo "    <h2>${name}</h2>"
             echo "    <img src=\"data:image/png;base64,${qr_b64}\" alt=\"QR code for ${name}\">"
-            echo "    <a class=\"btn\" href=\"configs/${name}.conf\" download=\"${name}.conf\">&#x2B07; Download Config</a>"
+            echo "    <a class=\"btn\" href=\"configs/${name}/client.conf\" download=\"${name}.conf\">&#x2B07; Download Config</a>"
             echo "  </div>"
         } >> "${www_dir}/index.html"
     done

--- a/wireguard/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard/rootfs/etc/cont-init.d/config.sh
@@ -296,13 +296,15 @@ for peer in $(bashio::config 'peers|keys'); do
     echo -n "${name}" > "/var/lib/wireguard/${filename}"
 done
 
-# Generate web interface files if enabled
+# Generate web interface files if enabled. These contain private-key-bearing
+# QR codes and client configs, so they are only ever served behind Home
+# Assistant Ingress (see services.d/webui/run), never on a raw open port.
 if bashio::config.true 'web_interface'; then
     bashio::log.info "Building web interface files..."
 
     www_dir="/var/lib/wireguard/www"
     rm -rf "${www_dir}"
-    mkdir -p "${www_dir}/cgi-bin" "${www_dir}/configs"
+    mkdir -p "${www_dir}/configs"
 
     # HTML header
     cat > "${www_dir}/index.html" << 'HTMLEOF'
@@ -329,7 +331,12 @@ h1{color:#38bdf8;margin:0 0 1.5rem}
 <div class="peers">
 HTMLEOF
 
-    # Add a card for every peer
+    # Add a card for every peer.
+    # SECURITY BOUNDARY: peer name is the only user value interpolated into the
+    # HTML and file paths below. It is safe unescaped ONLY because the schema in
+    # config.yaml constrains it to ^[a-zA-Z0-9-]{1,33}$ (no quotes, <, >, / or
+    # ..). Do not relax that regex without adding HTML-escaping and path
+    # sanitisation here.
     for peer in $(bashio::config 'peers|keys'); do
         name=$(bashio::config "peers[${peer}].name")
         config_dir="/ssl/wireguard/${name}"
@@ -344,7 +351,7 @@ HTMLEOF
             echo "  <div class=\"peer\">"
             echo "    <h2>${name}</h2>"
             echo "    <img src=\"data:image/png;base64,${qr_b64}\" alt=\"QR code for ${name}\">"
-            echo "    <a class=\"btn\" href=\"/configs/${name}.conf\" download=\"${name}.conf\">&#x2B07; Download Config</a>"
+            echo "    <a class=\"btn\" href=\"configs/${name}.conf\" download=\"${name}.conf\">&#x2B07; Download Config</a>"
             echo "  </div>"
         } >> "${www_dir}/index.html"
     done
@@ -356,43 +363,5 @@ HTMLEOF
 </html>
 HTMLEOF
 
-    # CGI script that mirrors the existing JSON status API
-    cat > "${www_dir}/cgi-bin/status" << 'CGIEOF'
-#!/bin/bash
-peers=()
-while IFS=$'\t' read -r -a line; do
-    if [[ "${#line[@]}" -gt 6 ]]; then
-        endpoint="${line[3]}"
-        latest_handshake="${line[5]}"
-        public_key="${line[1]}"
-        transfer_rx="${line[6]}"
-        transfer_tx="${line[7]}"
-
-        filename=$(sha1sum <<< "${public_key}" | awk '{ print $1 }')
-        if [[ -f "/var/lib/wireguard/${filename}" ]]; then
-            name=$(</var/lib/wireguard/${filename})
-            peers+=("${name}")
-            peers+=("{\"endpoint\":\"${endpoint}\",\"latest_handshake\":${latest_handshake},\"transfer_rx\":${transfer_rx},\"transfer_tx\":${transfer_tx}}")
-        fi
-    fi
-done <<< "$(wg show all dump)"
-
-json="{}"
-if [[ "${#peers[@]}" -ne 0 ]]; then
-    json="{"
-    sep=""
-    for ((i=0; i<${#peers[@]}; i+=2)); do
-        json="${json}${sep}\"${peers[i]}\":${peers[i+1]}"
-        sep=","
-    done
-    json="${json}}"
-fi
-
-printf "Content-Type: application/json\r\n\r\n"
-echo "${json}"
-CGIEOF
-    chmod +x "${www_dir}/cgi-bin/status"
-
-    bashio::log.info "Web interface ready – QR codes and configs served on port 80"
-    bashio::log.info "Status API available at /cgi-bin/status"
+    bashio::log.info "Web interface ready – open it via the add-on's Ingress UI"
 fi

--- a/wireguard/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard/rootfs/etc/cont-init.d/config.sh
@@ -295,3 +295,104 @@ for peer in $(bashio::config 'peers|keys'); do
     filename=$(sha1sum <<< "${peer_public_key}" | awk '{ print $1 }')
     echo -n "${name}" > "/var/lib/wireguard/${filename}"
 done
+
+# Generate web interface files if enabled
+if bashio::config.true 'web_interface'; then
+    bashio::log.info "Building web interface files..."
+
+    www_dir="/var/lib/wireguard/www"
+    rm -rf "${www_dir}"
+    mkdir -p "${www_dir}/cgi-bin" "${www_dir}/configs"
+
+    # HTML header
+    cat > "${www_dir}/index.html" << 'HTMLEOF'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>WireGuard — Peers</title>
+<style>
+body{font-family:system-ui,sans-serif;background:#0f172a;color:#e2e8f0;margin:0;padding:2rem}
+h1{color:#38bdf8;margin:0 0 1.5rem}
+.peers{display:flex;flex-wrap:wrap;gap:1.5rem}
+.peer{background:#1e293b;border-radius:.75rem;padding:1.5rem;text-align:center;min-width:220px}
+.peer h2{margin:0 0 1rem;color:#38bdf8;font-size:1rem;word-break:break-all}
+.peer img{display:block;margin:0 auto 1rem;max-width:200px;border-radius:.5rem}
+.btn{display:inline-block;padding:.5rem 1.25rem;background:#0ea5e9;color:#fff;
+     border-radius:.375rem;text-decoration:none;font-size:.875rem}
+.btn:hover{background:#38bdf8;color:#0f172a}
+</style>
+</head>
+<body>
+<h1>WireGuard Peers</h1>
+<div class="peers">
+HTMLEOF
+
+    # Add a card for every peer
+    for peer in $(bashio::config 'peers|keys'); do
+        name=$(bashio::config "peers[${peer}].name")
+        config_dir="/ssl/wireguard/${name}"
+
+        # Make the client config available for download
+        cp "${config_dir}/client.conf" "${www_dir}/configs/${name}.conf"
+
+        # Embed the QR code as a base64 data URI
+        qr_b64=$(base64 "${config_dir}/qrcode.png" | tr -d '\n')
+
+        {
+            echo "  <div class=\"peer\">"
+            echo "    <h2>${name}</h2>"
+            echo "    <img src=\"data:image/png;base64,${qr_b64}\" alt=\"QR code for ${name}\">"
+            echo "    <a class=\"btn\" href=\"/configs/${name}.conf\" download=\"${name}.conf\">&#x2B07; Download Config</a>"
+            echo "  </div>"
+        } >> "${www_dir}/index.html"
+    done
+
+    # HTML footer
+    cat >> "${www_dir}/index.html" << 'HTMLEOF'
+</div>
+</body>
+</html>
+HTMLEOF
+
+    # CGI script that mirrors the existing JSON status API
+    cat > "${www_dir}/cgi-bin/status" << 'CGIEOF'
+#!/bin/bash
+peers=()
+while IFS=$'\t' read -r -a line; do
+    if [[ "${#line[@]}" -gt 6 ]]; then
+        endpoint="${line[3]}"
+        latest_handshake="${line[5]}"
+        public_key="${line[1]}"
+        transfer_rx="${line[6]}"
+        transfer_tx="${line[7]}"
+
+        filename=$(sha1sum <<< "${public_key}" | awk '{ print $1 }')
+        if [[ -f "/var/lib/wireguard/${filename}" ]]; then
+            name=$(</var/lib/wireguard/${filename})
+            peers+=("${name}")
+            peers+=("{\"endpoint\":\"${endpoint}\",\"latest_handshake\":${latest_handshake},\"transfer_rx\":${transfer_rx},\"transfer_tx\":${transfer_tx}}")
+        fi
+    fi
+done <<< "$(wg show all dump)"
+
+json="{}"
+if [[ "${#peers[@]}" -ne 0 ]]; then
+    json="{"
+    sep=""
+    for ((i=0; i<${#peers[@]}; i+=2)); do
+        json="${json}${sep}\"${peers[i]}\":${peers[i+1]}"
+        sep=","
+    done
+    json="${json}}"
+fi
+
+printf "Content-Type: application/json\r\n\r\n"
+echo "${json}"
+CGIEOF
+    chmod +x "${www_dir}/cgi-bin/status"
+
+    bashio::log.info "Web interface ready – QR codes and configs served on port 80"
+    bashio::log.info "Status API available at /cgi-bin/status"
+fi

--- a/wireguard/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard/rootfs/etc/cont-init.d/config.sh
@@ -302,14 +302,24 @@ done
 # Generate web interface files if enabled. These contain private-key-bearing
 # QR codes and client configs, so they are only ever served behind Home
 # Assistant Ingress (see services.d/webui/run), never on a raw open port.
+# Wiped unconditionally first, so turning the option off also drops the key
+# material generated while it was on.
+www_dir="/var/lib/wireguard/www"
+rm -rf "${www_dir}" ||
+    bashio::exit.nok "Could not remove stale web interface files"
+
 if bashio::config.true 'web_interface'; then
     bashio::log.info "Building web interface files..."
 
-    www_dir="/var/lib/wireguard/www"
-    rm -rf "${www_dir}"
-    mkdir -p "${www_dir}/configs"
+    # 0700/0600 throughout: the tree holds peer private keys.
+    install -d -m 0700 "${www_dir}/configs" ||
+        bashio::exit.nok "Could not create web interface folder"
 
-    # HTML header
+    # HTML header. Created empty with an explicit mode first — the page embeds
+    # every peer's private key, and `>` alone would leave it at the umask.
+    install -m 0600 /dev/null "${www_dir}/index.html" ||
+        bashio::exit.nok "Could not create web interface index"
+
     cat > "${www_dir}/index.html" << 'HTMLEOF'
 <!DOCTYPE html>
 <html lang="en">
@@ -374,13 +384,17 @@ HTMLEOF
         # "configs/${name}.conf" would become "httpd.conf" for a peer named
         # "httpd" (a schema-valid name), which BusyBox httpd reserves as its
         # per-directory config file and refuses to serve (403).
-        # ${www_dir} is recreated from scratch above, so there is no previous
-        # copy to preserve — on failure just drop the peer's directory again so
-        # the page never links to a config that is missing or truncated.
+        # 0700/0600 rather than the umask default: this tree holds every peer's
+        # private key. ${www_dir} is recreated from scratch above, so there is
+        # no previous copy to preserve — on failure just drop the peer's
+        # directory again, so the page never links to a config that is missing
+        # or truncated. A failed card skips the peer rather than aborting init:
+        # the VPN itself must not stop serving because a QR page could not be
+        # built.
         peer_www_dir="${www_dir}/configs/${name}"
-        if ! mkdir -p "${peer_www_dir}" \
-            || ! cp "${config_dir}/client.conf" \
-                "${peer_www_dir}/client.conf" 2>/dev/null; then
+        if ! install -d -m 0700 "${peer_www_dir}" \
+            || ! install -m 0600 "${config_dir}/client.conf" \
+                "${peer_www_dir}/client.conf"; then
             bashio::log.warning \
                 "Skipping web card for ${name}: could not publish client.conf"
             rm -rf "${peer_www_dir}"

--- a/wireguard/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard/rootfs/etc/cont-init.d/config.sh
@@ -356,13 +356,18 @@ HTMLEOF
 
         # Read the QR code as a base64 data URI *before* touching index.html:
         # a failed read must skip the peer, not append a card with a broken
-        # <img> to the page.
-        if ! qr_b64=$(base64 "${config_dir}/qrcode.png" 2>/dev/null | tr -d '\n') \
+        # <img> to the page. Note this deliberately does not pipe into
+        # `tr -d '\n'` to unwrap base64's 76-column output: the pipeline's exit
+        # status would be tr's, so a base64 that dies partway through — leaving
+        # a truncated data URI — would still look like success. Strip the
+        # newlines in the shell instead, keeping base64's own status.
+        if ! qr_b64=$(base64 "${config_dir}/qrcode.png" 2>/dev/null) \
             || bashio::var.is_empty "${qr_b64}"; then
             bashio::log.warning \
                 "Skipping web card for ${name}: could not read qrcode.png"
             continue
         fi
+        qr_b64="${qr_b64//$'\n'/}"
 
         # Make the client config available for download, from a per-peer
         # subdirectory so the served basename is always "client.conf". A flat

--- a/wireguard/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard/rootfs/etc/cont-init.d/config.sh
@@ -341,6 +341,16 @@ HTMLEOF
         name=$(bashio::config "peers[${peer}].name")
         config_dir="/ssl/wireguard/${name}"
 
+        # Both files are generated for every peer in the loop above, so this
+        # should never trigger — but skip (with a warning) rather than emit a
+        # broken card if one is missing, e.g. after a failed qrencode run.
+        if ! bashio::fs.file_exists "${config_dir}/client.conf" \
+            || ! bashio::fs.file_exists "${config_dir}/qrcode.png"; then
+            bashio::log.warning \
+                "Skipping web card for ${name}: client.conf or qrcode.png missing"
+            continue
+        fi
+
         # Make the client config available for download
         cp "${config_dir}/client.conf" "${www_dir}/configs/${name}.conf"
 

--- a/wireguard/rootfs/etc/cont-init.d/config.sh
+++ b/wireguard/rootfs/etc/cont-init.d/config.sh
@@ -19,15 +19,18 @@ declare mtu
 declare name
 declare peer_private_key
 declare peer_public_key
+declare peer_www_dir
 declare port
 declare post_down
 declare post_up
 declare pre_down
 declare pre_shared_key
 declare pre_up
+declare qr_b64
 declare server_private_key
 declare server_public_key
 declare table
+declare www_dir
 
 if ! bashio::fs.directory_exists '/ssl/wireguard'; then
     mkdir -p /ssl/wireguard ||
@@ -351,16 +354,33 @@ HTMLEOF
             continue
         fi
 
+        # Read the QR code as a base64 data URI *before* touching index.html:
+        # a failed read must skip the peer, not append a card with a broken
+        # <img> to the page.
+        if ! qr_b64=$(base64 "${config_dir}/qrcode.png" 2>/dev/null | tr -d '\n') \
+            || bashio::var.is_empty "${qr_b64}"; then
+            bashio::log.warning \
+                "Skipping web card for ${name}: could not read qrcode.png"
+            continue
+        fi
+
         # Make the client config available for download, from a per-peer
         # subdirectory so the served basename is always "client.conf". A flat
         # "configs/${name}.conf" would become "httpd.conf" for a peer named
         # "httpd" (a schema-valid name), which BusyBox httpd reserves as its
         # per-directory config file and refuses to serve (403).
-        mkdir -p "${www_dir}/configs/${name}"
-        cp "${config_dir}/client.conf" "${www_dir}/configs/${name}/client.conf"
-
-        # Embed the QR code as a base64 data URI
-        qr_b64=$(base64 "${config_dir}/qrcode.png" | tr -d '\n')
+        # ${www_dir} is recreated from scratch above, so there is no previous
+        # copy to preserve — on failure just drop the peer's directory again so
+        # the page never links to a config that is missing or truncated.
+        peer_www_dir="${www_dir}/configs/${name}"
+        if ! mkdir -p "${peer_www_dir}" \
+            || ! cp "${config_dir}/client.conf" \
+                "${peer_www_dir}/client.conf" 2>/dev/null; then
+            bashio::log.warning \
+                "Skipping web card for ${name}: could not publish client.conf"
+            rm -rf "${peer_www_dir}"
+            continue
+        fi
 
         {
             echo "  <div class=\"peer\">"

--- a/wireguard/rootfs/etc/httpd.conf
+++ b/wireguard/rootfs/etc/httpd.conf
@@ -1,0 +1,9 @@
+# busybox httpd configuration for the optional web interface.
+#
+# Defense in depth: only accept connections from the Home Assistant Ingress
+# proxy (172.30.32.2) and deny everything else, so other add-ons sharing the
+# internal Supervisor network cannot reach the private-key-bearing QR codes and
+# client configs directly, bypassing Home Assistant authentication.
+# https://developers.home-assistant.io/docs/add-ons/presentation#ingress
+A:172.30.32.2
+D:*

--- a/wireguard/rootfs/etc/services.d/api/run
+++ b/wireguard/rootfs/etc/services.d/api/run
@@ -1,9 +1,19 @@
 #!/command/with-contenv bashio
 # ==============================================================================
 # Home Assistant Community Add-on: WireGuard
-# The most simple HTTP API you've ever seen.
-# Provides status of WireGuard peers.
+# Serves either the lightweight web interface (QR codes + config downloads +
+# JSON status API via CGI) or the simple nc-based JSON status API, depending
+# on the `web_interface` configuration option.
 # ==============================================================================
+
+if bashio::config.true 'web_interface'; then
+    bashio::log.info "Starting WireGuard web interface on port 80..."
+    exec busybox httpd -f -p 80 -h /var/lib/wireguard/www
+fi
+
+# ---------------------------------------------------------------------------
+# Fallback: original nc-based JSON status API (web_interface is disabled)
+# ---------------------------------------------------------------------------
 declare -a peers
 declare endpoint
 declare json

--- a/wireguard/rootfs/etc/services.d/api/run
+++ b/wireguard/rootfs/etc/services.d/api/run
@@ -1,19 +1,9 @@
 #!/command/with-contenv bashio
 # ==============================================================================
 # Home Assistant Community Add-on: WireGuard
-# Serves either the lightweight web interface (QR codes + config downloads +
-# JSON status API via CGI) or the simple nc-based JSON status API, depending
-# on the `web_interface` configuration option.
+# The most simple HTTP API you've ever seen.
+# Provides status of WireGuard peers.
 # ==============================================================================
-
-if bashio::config.true 'web_interface'; then
-    bashio::log.info "Starting WireGuard web interface on port 80..."
-    exec busybox httpd -f -p 80 -h /var/lib/wireguard/www
-fi
-
-# ---------------------------------------------------------------------------
-# Fallback: original nc-based JSON status API (web_interface is disabled)
-# ---------------------------------------------------------------------------
 declare -a peers
 declare endpoint
 declare json

--- a/wireguard/rootfs/etc/services.d/webui/run
+++ b/wireguard/rootfs/etc/services.d/webui/run
@@ -10,9 +10,19 @@
 # ==============================================================================
 
 if ! bashio::config.true 'web_interface'; then
-    # Disabled: mark run-once so s6 leaves the service down instead of looping.
-    s6-svc -O /run/service/webui
-    exit 0
+    # `ingress: true` is static, so Home Assistant shows the "Open Web UI"
+    # button regardless. Serve a notice instead of exiting: an empty port there
+    # reads as a broken add-on rather than a disabled feature.
+    notice_dir="/var/lib/wireguard/www-disabled"
+    mkdir -p "${notice_dir}"
+    cat > "${notice_dir}/index.html" << 'HTMLEOF'
+<!DOCTYPE html><meta charset="UTF-8"><title>WireGuard</title>
+<body style="font-family:system-ui,sans-serif;background:#0f172a;color:#e2e8f0;padding:2rem">
+<h1 style="color:#38bdf8">Web interface disabled</h1>
+<p>Set <code>web_interface: true</code> in the add-on configuration and restart
+to show peer QR codes and client config downloads here.</p>
+HTMLEOF
+    exec httpd -f -p 8099 -c /etc/httpd.conf -h "${notice_dir}"
 fi
 
 bashio::log.info "Starting WireGuard web interface behind Ingress (port 8099)..."

--- a/wireguard/rootfs/etc/services.d/webui/run
+++ b/wireguard/rootfs/etc/services.d/webui/run
@@ -12,17 +12,11 @@
 if ! bashio::config.true 'web_interface'; then
     # `ingress: true` is static, so Home Assistant shows the "Open Web UI"
     # button regardless. Serve a notice instead of exiting: an empty port there
-    # reads as a broken add-on rather than a disabled feature.
-    notice_dir="/var/lib/wireguard/www-disabled"
-    mkdir -p "${notice_dir}"
-    cat > "${notice_dir}/index.html" << 'HTMLEOF'
-<!DOCTYPE html><meta charset="UTF-8"><title>WireGuard</title>
-<body style="font-family:system-ui,sans-serif;background:#0f172a;color:#e2e8f0;padding:2rem">
-<h1 style="color:#38bdf8">Web interface disabled</h1>
-<p>Set <code>web_interface: true</code> in the add-on configuration and restart
-to show peer QR codes and client config downloads here.</p>
-HTMLEOF
-    exec httpd -f -p 8099 -c /etc/httpd.conf -h "${notice_dir}"
+    # reads as a broken add-on rather than a disabled feature. The notice ships
+    # in the image (rootfs/var/www-disabled) rather than being written here:
+    # it is a constant, and generating it at every start only adds a way to end
+    # up serving an empty document root.
+    exec httpd -f -p 8099 -c /etc/httpd.conf -h /var/www-disabled
 fi
 
 bashio::log.info "Starting WireGuard web interface behind Ingress (port 8099)..."

--- a/wireguard/rootfs/etc/services.d/webui/run
+++ b/wireguard/rootfs/etc/services.d/webui/run
@@ -1,0 +1,21 @@
+#!/command/with-contenv bashio
+# ==============================================================================
+# Home Assistant Community Add-on: WireGuard
+# Serves the optional web interface (QR codes + client config downloads).
+#
+# The served files contain the peers' private keys, so they are exposed ONLY
+# through Home Assistant Ingress (see `ingress` in config.yaml) — never on a
+# raw, unauthenticated port. This runs independently of the status API service,
+# which keeps serving JSON on port 80 unchanged.
+# ==============================================================================
+
+if ! bashio::config.true 'web_interface'; then
+    # Disabled: mark run-once so s6 leaves the service down instead of looping.
+    s6-svc -O /run/service/webui
+    exit 0
+fi
+
+bashio::log.info "Starting WireGuard web interface behind Ingress (port 8099)..."
+# httpd is provided by the busybox-extras package (stock busybox lacks the
+# applet). -c applies the Ingress-only source-IP allowlist (see /etc/httpd.conf).
+exec httpd -f -p 8099 -c /etc/httpd.conf -h /var/lib/wireguard/www

--- a/wireguard/rootfs/var/www-disabled/index.html
+++ b/wireguard/rootfs/var/www-disabled/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html><meta charset="UTF-8"><title>WireGuard</title>
+<body style="font-family:system-ui,sans-serif;background:#0f172a;color:#e2e8f0;padding:2rem">
+<h1 style="color:#38bdf8">Web interface disabled</h1>
+<p>Set <code>web_interface: true</code> in the add-on configuration and restart
+to show peer QR codes and client config downloads here.</p>

--- a/wireguard/tests/webui-acl-smoke.sh
+++ b/wireguard/tests/webui-acl-smoke.sh
@@ -5,46 +5,89 @@
 # The web UI serves private-key-bearing QR codes and client configs, so it must
 # be reachable ONLY through the Home Assistant Ingress proxy (172.30.32.2). This
 # test guards two things that would silently break that boundary:
-#   1. an httpd exists to serve the UI (stock busybox has no httpd applet, so the
-#      Dockerfile must install busybox-extras);
-#   2. rootfs/etc/httpd.conf actually enforces the Ingress-only source-IP ACL.
+#   1. the add-on image ships an httpd to serve the UI (stock busybox has no
+#      httpd applet, so the Dockerfile must install busybox-extras);
+#   2. the /etc/httpd.conf baked into that image enforces the Ingress-only
+#      source-IP ACL — the proxy address is served, every other source is not.
 #
-# It runs against the same base image the add-on builds from (read from
-# build.yaml) and needs only Docker. Runnable locally: bash webui-acl-smoke.sh
+# Both are checked against the real add-on image built from the add-on's
+# Dockerfile. The test installs nothing and writes no config of its own, so
+# dropping busybox-extras or loosening the ACL fails here instead of shipping.
+#
+# Needs Docker, and CAP_NET_ADMIN in the test container to impersonate the
+# Ingress proxy address. Runnable locally: bash webui-acl-smoke.sh
+# Set WEBUI_SMOKE_IMAGE=<tag> to test an already-built image and skip the build.
 # =============================================================================
 set -euo pipefail
 
 addon_dir="$(cd "$(dirname "$0")/.." && pwd)"
 conf="${addon_dir}/rootfs/etc/httpd.conf"
-base="$(grep -m1 -E '^\s*amd64:' "${addon_dir}/build.yaml" | awk '{print $2}')"
+image="${WEBUI_SMOKE_IMAGE:-}"
 
 test -f "${conf}" || { echo "FAIL: ${conf} not found"; exit 1; }
-test -n "${base}" || { echo "FAIL: could not read amd64 base image from build.yaml"; exit 1; }
-echo "Base image: ${base}"
 
-docker run --rm --entrypoint /bin/busybox \
-    -v "${conf}:/etc/httpd.conf:ro" "${base}" sh -c '
-    set -e
-    apk add --no-cache busybox-extras >/dev/null
-    command -v httpd >/dev/null || { echo "FAIL: httpd applet missing (need busybox-extras)"; exit 1; }
-    echo "OK: httpd available"
+# The ACL is the security boundary, so assert the exact rules and their order:
+# busybox httpd evaluates them top-down, and an allow rule that lands after the
+# catch-all deny is dead. Anything else here is a change that must be reviewed.
+if [[ "$(grep -E '^[ADI]:' "${conf}")" != "$(printf 'A:172.30.32.2\nD:*')" ]]; then
+    echo "FAIL: ${conf} must contain exactly 'A:172.30.32.2' then 'D:*'"
+    exit 1
+fi
+echo "OK: httpd.conf declares the Ingress-only ACL"
 
-    mkdir -p /tmp/www; echo "PRIVATE-KEY-MATERIAL" > /tmp/www/index.html
+if [[ -z "${image}" ]]; then
+    image="addon-wireguard:webui-smoke"
+    base="$(grep -m1 -E '^\s*amd64:' "${addon_dir}/build.yaml" | awk '{print $2}')"
+    test -n "${base}" || { echo "FAIL: could not read amd64 base from build.yaml"; exit 1; }
+    echo "Building ${image} from ${base}..."
+    docker build --build-arg "BUILD_FROM=${base}" -t "${image}" "${addon_dir}"
+fi
+echo "Image under test: ${image}"
 
-    # 1) A client that is NOT the Ingress proxy must be denied by the repo ACL.
+docker run --rm --cap-add=NET_ADMIN --entrypoint /bin/bash "${image}" -c '
+    set -eu
+
+    # No apk install here on purpose: the add-on image itself must provide it.
+    command -v httpd >/dev/null || {
+        echo "FAIL: httpd missing from the add-on image (need busybox-extras)"
+        exit 1
+    }
+    echo "OK: httpd present in the add-on image"
+
+    mkdir -p /tmp/www
+    echo "PRIVATE-KEY-MATERIAL" > /tmp/www/index.html
+
+    # Impersonate the Supervisor Ingress proxy, so the allowed source address is
+    # exercised for real rather than stood in for by a local-only test rule.
+    ip addr add 172.30.32.2/32 dev lo || {
+        echo "FAIL: could not add the Ingress proxy address (needs NET_ADMIN)"
+        exit 1
+    }
+
+    # One server, serving the config that ships in the image.
     httpd -f -p 8099 -c /etc/httpd.conf -h /tmp/www &
-    sleep 2
-    code=$(wget -S -qO- http://127.0.0.1:8099/ 2>&1 | awk "/HTTP\//{print \$2; exit}")
-    [ "${code}" = "403" ] || { echo "FAIL: expected 403 for non-Ingress client, got ${code}"; exit 1; }
-    echo "OK: non-Ingress client denied (403)"
+    ready=""
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        # Any HTTP status means it is listening; curl only fails to connect.
+        if curl -s -o /dev/null http://127.0.0.1:8099/; then ready="yes"; break; fi
+        sleep 1
+    done
+    [ -n "${ready}" ] || { echo "FAIL: httpd did not start"; exit 1; }
 
-    # 2) Control: an explicitly-allowed client is served, proving the ACL is
-    #    active (accept + deny both work), not a blanket deny that fakes success.
-    printf "A:127.0.0.1\nD:*\n" > /tmp/allow.conf
-    httpd -f -p 8100 -c /tmp/allow.conf -h /tmp/www &
-    sleep 2
-    code=$(wget -S -qO- http://127.0.0.1:8100/ 2>&1 | awk "/HTTP\//{print \$2; exit}")
-    [ "${code}" = "200" ] || { echo "FAIL: expected 200 for allowed client, got ${code}"; exit 1; }
-    echo "OK: allowed client served (200)"
+    # 1) The Ingress proxy is served.
+    code=$(curl -s -o /dev/null -w "%{http_code}" http://172.30.32.2:8099/)
+    [ "${code}" = "200" ] || {
+        echo "FAIL: expected 200 for the Ingress proxy, got ${code}"
+        exit 1
+    }
+    echo "OK: Ingress proxy served (200)"
+
+    # 2) Everything else is denied by that same server and config.
+    code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8099/)
+    [ "${code}" = "403" ] || {
+        echo "FAIL: expected 403 for non-Ingress client, got ${code}"
+        exit 1
+    }
+    echo "OK: non-Ingress client denied (403)"
 '
 echo "Web UI ACL smoke test passed."

--- a/wireguard/tests/webui-acl-smoke.sh
+++ b/wireguard/tests/webui-acl-smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Smoke test for the optional web interface (web_interface: true).
+#
+# The web UI serves private-key-bearing QR codes and client configs, so it must
+# be reachable ONLY through the Home Assistant Ingress proxy (172.30.32.2). This
+# test guards two things that would silently break that boundary:
+#   1. an httpd exists to serve the UI (stock busybox has no httpd applet, so the
+#      Dockerfile must install busybox-extras);
+#   2. rootfs/etc/httpd.conf actually enforces the Ingress-only source-IP ACL.
+#
+# It runs against the same base image the add-on builds from (read from
+# build.yaml) and needs only Docker. Runnable locally: bash webui-acl-smoke.sh
+# =============================================================================
+set -euo pipefail
+
+addon_dir="$(cd "$(dirname "$0")/.." && pwd)"
+conf="${addon_dir}/rootfs/etc/httpd.conf"
+base="$(grep -m1 -E '^\s*amd64:' "${addon_dir}/build.yaml" | awk '{print $2}')"
+
+test -f "${conf}" || { echo "FAIL: ${conf} not found"; exit 1; }
+test -n "${base}" || { echo "FAIL: could not read amd64 base image from build.yaml"; exit 1; }
+echo "Base image: ${base}"
+
+docker run --rm --entrypoint /bin/busybox \
+    -v "${conf}:/etc/httpd.conf:ro" "${base}" sh -c '
+    set -e
+    apk add --no-cache busybox-extras >/dev/null
+    command -v httpd >/dev/null || { echo "FAIL: httpd applet missing (need busybox-extras)"; exit 1; }
+    echo "OK: httpd available"
+
+    mkdir -p /tmp/www; echo "PRIVATE-KEY-MATERIAL" > /tmp/www/index.html
+
+    # 1) A client that is NOT the Ingress proxy must be denied by the repo ACL.
+    httpd -f -p 8099 -c /etc/httpd.conf -h /tmp/www &
+    sleep 2
+    code=$(wget -S -qO- http://127.0.0.1:8099/ 2>&1 | awk "/HTTP\//{print \$2; exit}")
+    [ "${code}" = "403" ] || { echo "FAIL: expected 403 for non-Ingress client, got ${code}"; exit 1; }
+    echo "OK: non-Ingress client denied (403)"
+
+    # 2) Control: an explicitly-allowed client is served, proving the ACL is
+    #    active (accept + deny both work), not a blanket deny that fakes success.
+    printf "A:127.0.0.1\nD:*\n" > /tmp/allow.conf
+    httpd -f -p 8100 -c /tmp/allow.conf -h /tmp/www &
+    sleep 2
+    code=$(wget -S -qO- http://127.0.0.1:8100/ 2>&1 | awk "/HTTP\//{print \$2; exit}")
+    [ "${code}" = "200" ] || { echo "FAIL: expected 200 for allowed client, got ${code}"; exit 1; }
+    echo "OK: allowed client served (200)"
+'
+echo "Web UI ACL smoke test passed."

--- a/wireguard/tests/webui-acl-smoke.sh
+++ b/wireguard/tests/webui-acl-smoke.sh
@@ -5,18 +5,23 @@
 # The web UI serves private-key-bearing QR codes and client configs, so it must
 # be reachable ONLY through the Home Assistant Ingress proxy (172.30.32.2). This
 # test guards two things that would silently break that boundary:
-#   1. the add-on image ships an httpd to serve the UI (stock busybox has no
-#      httpd applet, so the Dockerfile must install busybox-extras);
-#   2. the /etc/httpd.conf baked into that image enforces the Ingress-only
-#      source-IP ACL — the proxy address is served, every other source is not.
+#   1. the add-on installs an httpd to serve the UI — stock busybox has no httpd
+#      applet, so the Dockerfile must pull in busybox-extras;
+#   2. rootfs/etc/httpd.conf enforces the Ingress-only source-IP ACL: the proxy
+#      address is served, every other source is not.
 #
-# Both are checked against the real add-on image built from the add-on's
-# Dockerfile. The test installs nothing and writes no config of its own, so
-# dropping busybox-extras or loosening the ACL fails here instead of shipping.
+# Both are checked against what the add-on itself declares. The httpd package is
+# read out of the Dockerfile rather than installed by name here, so dropping or
+# renaming that dependency fails this test instead of shipping a web UI that
+# cannot start. The ACL is exercised as it ships, from a real 172.30.32.2 source
+# address — no stand-in config, no stand-in client.
 #
-# Needs Docker, and CAP_NET_ADMIN in the test container to impersonate the
-# Ingress proxy address. Runnable locally: bash webui-acl-smoke.sh
-# Set WEBUI_SMOKE_IMAGE=<tag> to test an already-built image and skip the build.
+# Needs Docker, and CAP_NET_ADMIN in the test container to take the Ingress
+# proxy address. Runnable locally: bash webui-acl-smoke.sh
+# Set WEBUI_SMOKE_IMAGE=<tag> to run the same assertions against an already
+# built add-on image — the strongest form of this test, but it needs the full
+# add-on build (Go toolchain + git.zx2c4.com), which is the release pipeline's
+# job, not this test's.
 # =============================================================================
 set -euo pipefail
 
@@ -27,7 +32,7 @@ image="${WEBUI_SMOKE_IMAGE:-}"
 test -f "${conf}" || { echo "FAIL: ${conf} not found"; exit 1; }
 
 # The ACL is the security boundary, so assert the exact rules and their order:
-# busybox httpd evaluates them top-down, and an allow rule that lands after the
+# busybox httpd evaluates them top-down, so an allow rule that lands after the
 # catch-all deny is dead. Anything else here is a change that must be reviewed.
 if [[ "$(grep -E '^[ADI]:' "${conf}")" != "$(printf 'A:172.30.32.2\nD:*')" ]]; then
     echo "FAIL: ${conf} must contain exactly 'A:172.30.32.2' then 'D:*'"
@@ -36,35 +41,56 @@ fi
 echo "OK: httpd.conf declares the Ingress-only ACL"
 
 if [[ -z "${image}" ]]; then
-    image="addon-wireguard:webui-smoke"
     base="$(grep -m1 -E '^\s*amd64:' "${addon_dir}/build.yaml" | awk '{print $2}')"
     test -n "${base}" || { echo "FAIL: could not read amd64 base from build.yaml"; exit 1; }
-    echo "Building ${image} from ${base}..."
-    docker build --build-arg "BUILD_FROM=${base}" -t "${image}" "${addon_dir}"
+
+    # Take the httpd package straight from the add-on's Dockerfile, pin and all.
+    # This is what makes the check below meaningful: an unconditional
+    # `apk add busybox-extras` here would keep passing after the Dockerfile
+    # stopped installing it.
+    httpd_pkg="$(grep -m1 -oE 'busybox-extras(=[^ \\]+)?' "${addon_dir}/Dockerfile" || true)"
+    test -n "${httpd_pkg}" || {
+        echo "FAIL: wireguard/Dockerfile no longer installs busybox-extras, so"
+        echo "      the add-on image has no httpd applet and the web UI is dead."
+        exit 1
+    }
+    echo "Dockerfile httpd package: ${httpd_pkg}"
+
+    image="addon-wireguard:webui-smoke"
+    docker build -q -t "${image}" -f - "${addon_dir}" > /dev/null << EOF
+FROM ${base}
+RUN apk add --no-cache ${httpd_pkg}
+COPY rootfs/etc/httpd.conf /etc/httpd.conf
+EOF
 fi
 echo "Image under test: ${image}"
 
+# MSYS_NO_PATHCONV keeps Git Bash on Windows from rewriting the in-container
+# paths below into Windows ones; it is ignored elsewhere. Scoped to this command
+# because the build above does want its context path translated.
+MSYS_NO_PATHCONV=1 \
 docker run --rm --cap-add=NET_ADMIN --entrypoint /bin/bash "${image}" -c '
     set -eu
 
-    # No apk install here on purpose: the add-on image itself must provide it.
+    # Nothing is installed here on purpose: the packages the add-on declares
+    # must be what provides this.
     command -v httpd >/dev/null || {
-        echo "FAIL: httpd missing from the add-on image (need busybox-extras)"
+        echo "FAIL: httpd missing — busybox-extras did not provide the applet"
         exit 1
     }
-    echo "OK: httpd present in the add-on image"
+    echo "OK: httpd present"
 
     mkdir -p /tmp/www
     echo "PRIVATE-KEY-MATERIAL" > /tmp/www/index.html
 
-    # Impersonate the Supervisor Ingress proxy, so the allowed source address is
+    # Take the Supervisor Ingress proxy address, so the allowed source is
     # exercised for real rather than stood in for by a local-only test rule.
     ip addr add 172.30.32.2/32 dev lo || {
         echo "FAIL: could not add the Ingress proxy address (needs NET_ADMIN)"
         exit 1
     }
 
-    # One server, serving the config that ships in the image.
+    # One server, serving the ACL exactly as it ships.
     httpd -f -p 8099 -c /etc/httpd.conf -h /tmp/www &
     ready=""
     for _ in 1 2 3 4 5 6 7 8 9 10; do
@@ -82,7 +108,7 @@ docker run --rm --cap-add=NET_ADMIN --entrypoint /bin/bash "${image}" -c '
     }
     echo "OK: Ingress proxy served (200)"
 
-    # 2) Everything else is denied by that same server and config.
+    # 2) Every other source is denied by that same server and config.
     code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8099/)
     [ "${code}" = "403" ] || {
         echo "FAIL: expected 403 for non-Ingress client, got ${code}"


### PR DESCRIPTION
# Proposed Changes

Adds an **opt-in** web UI that shows each WireGuard peer's QR code and offers one-click client-config downloads, so onboarding a device no longer requires digging through `/ssl/wireguard/` on the host.

### Access model (security)

The QR codes and `client.conf` files contain each peer's **private key**, so the UI is served **only** through Home Assistant Ingress — authenticated, and never on a raw open port:

- `ingress: true` / `ingress_port: 8099`; opened via the add-on's **"Open Web UI"** button.
- A dedicated, s6-supervised `webui` service runs `busybox httpd` on `8099`, and `httpd.conf` restricts the port to the Supervisor Ingress proxy (`172.30.32.2`) as defence in depth.
- The generated tree is created `0700`/`0600` — including `index.html`, which embeds the same key material in its QR codes — and is wiped on every start, so turning the option back off drops what was generated while it was on.

Transport encryption is whatever the Home Assistant entry point itself uses: Ingress proxies this over the internal Supervisor network, so it is end-to-end encrypted only where Home Assistant is reached over HTTPS. The docs say so rather than claiming TLS on the add-on's behalf.

### Status API — unchanged

`services.d/api/run` is **byte-identical to `main`**: the JSON status API keeps serving on port 80 exactly as before, so existing REST sensors are unaffected. (No `/cgi-bin/status`; enabling the UI does not touch the status API.)

### What changed

- **`config.yaml`** — `web_interface: bool?` (off by default) + `ingress` / `ingress_port`.
- **`cont-init.d/config.sh`** — when enabled, generates `/var/lib/wireguard/www/`: a self-contained `index.html` (inline base64 QR codes + relative download links) and per-peer `configs/<name>/client.conf` static files, all with explicit `0700`/`0600` modes. A peer whose files are missing, or whose QR read or config copy fails, is skipped with a warning rather than half-written into the page — a failed card must not take down the VPN itself.
- **`services.d/webui/run`** — new supervised service. When the option is off it serves a short "web interface disabled" notice through the same Ingress-only ACL, because `ingress: true` is static: the **"Open Web UI"** button exists either way, and an empty port behind it reads as a broken add-on.
- **`Dockerfile`** — adds `busybox-extras` (**stock Alpine busybox has no `httpd` applet**, so the UI cannot run without it).
- **`tests/webui-acl-smoke.sh`** + CI job — assert `httpd` availability and the Ingress-only ACL. The test installs the `busybox-extras` spec it reads out of the `Dockerfile` rather than naming the package itself, so dropping that dependency fails the test instead of passing; and it exercises the shipped `httpd.conf` from a real `172.30.32.2` source address, rather than a stand-in `A:127.0.0.1` config.
- **`DOCS.md`** — documents the option, its Ingress access model, and the unchanged status API.

### Note for maintainers

The `Dockerfile` also pins `musl=1.2.5-r12`. `base:19.0.0` pins `musl=r10` in its `world`, but the current Alpine 3.22 repo's `build-base` → `musl-dev` requires `r12`, so the image no longer builds against live repos without it (this affects `main` too, independent of this PR). It is commented as temporary — happy to drop it in favour of a base-image bump if you'd prefer to handle it that way.

Everything was verified against `ghcr.io/hassio-addons/base:19.0.0` with Docker: `httpd` present via `busybox-extras`, the Ingress-only ACL enforced (403 for a non-proxy client, 200 for the proxy), the missing-file guard, the reserved-`httpd.conf` basename fix (a peer named `httpd` is now served correctly), the `0700`/`0600` modes actually applied, the disabled-notice path serving only to Ingress and carrying no key material, and the full `apk` install resolving.

The smoke test was also checked for the failure it is supposed to catch — it fails, as intended, when `busybox-extras` is dropped from the `Dockerfile`, when the ACL is loosened or its rules are reordered, and on each of its 200 and 403 assertions independently. (Worth knowing if that ACL is ever edited: `A:*` is not a valid BusyBox allow-wildcard and denies everything.)

Review feedback has been applied, including the `checkout` credential persistence, the encryption wording above, atomicity of the generated peer artifacts, and both smoke-test findings.

## Related Issues

> _(none)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Home Assistant Ingress–only Web UI listing WireGuard peers with QR codes and downloadable client configurations.
  * Exposed the Web UI through Ingress on port **8099**; disabled mode displays a notice and clears generated assets at startup.
* **Bug Fixes**
  * Improved Alpine/musl build reliability.
* **Tests**
  * Added a smoke test and CI job verifying the Web UI and strict Ingress-only access.
* **Documentation**
  * Documented the `web_interface` setting, access behavior, security considerations, and unchanged status API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
